### PR TITLE
Fix height adjustments for narrow SVGs

### DIFF
--- a/assets/js/fix-plantuml-aspect-ratio.js
+++ b/assets/js/fix-plantuml-aspect-ratio.js
@@ -2,16 +2,19 @@ document.addEventListener("DOMContentLoaded", function() {
     const svgs = document.querySelectorAll('svg.plantuml');
     svgs.forEach(function(svg) {
         // Actual width of the parent container of SVG
-        const width = svg.parentElement.offsetWidth;
+        const parentWidth = svg.parentElement.offsetWidth;
 
         // Aspect ratio of the original SVG
         const svgWidth = svg.viewBox.baseVal.width;
         const svgHeight = svg.viewBox.baseVal.height;
         const svgAspectRatio = svgWidth / svgHeight;
 
+        // Compute desired width as the lower of the two
+        const width = Math.min(svgWidth, parentWidth);
+
         // Computed height of the 
         const height = width / svgAspectRatio;
-
+        
         // Set aspect ratio rules and desired height to crop excessively tall SVG viewbox
         svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
         svg.style.height = `${height}px`

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -221,6 +221,8 @@ body {
       display: block;
       max-width: 100%;
       height: auto;
+      margin-left: auto;
+      margin-right: auto;
     }
 
     .page-content {


### PR DESCRIPTION
- Take into account actual SVG width to compute desired height
- Center diagrams so that smaller ones are no longer left-aligned