### PR TITLE
Address styling issues

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,8 @@
 
     {%- include footer.html -%}
 
+    <div id="end-of-doc-marker"></div>
+
   </body>
 
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -35,7 +35,8 @@ layout: default
 {% include social-share.html page=page %}
 
 {% if site.giscus.enabled %}
-<script src="https://giscus.app/client.js"
+<script id="giscus-script"
+        src="https://giscus.app/client.js"
         data-repo="{{ site.giscus.data_repo }}"
         data-repo-id="{{ site.giscus.data_repo_id }}"
         data-category="{{ site.giscus.data_category }}"

--- a/assets/js/site-appearance.js
+++ b/assets/js/site-appearance.js
@@ -17,6 +17,8 @@ const themeKey = "theme";
 const contrastKey = "contrast";
 const fontSizeKey = "fontSize";
 
+loadAppearanceFromLocalStorage();
+
 onTerminalElementLoaded(loadAppearanceFromLocalStorage);
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -370,9 +370,11 @@ li.post-listing h3 {
   @include respond-to(mobile) {
     aspect-ratio: 1.5;
   }
-
   @media (max-width: 640px) {
     aspect-ratio: 1;
+  }
+  &#related-posts {
+    aspect-ratio: unset;
   }
 }
 
@@ -628,6 +630,7 @@ tbody tr:nth-child(2n) {
 .stock img {
   width: 100%;
   max-width: 100%;
+  aspect-ratio: 4;
   margin-left: auto;
   margin-right: auto;
   object-fit: cover;


### PR DESCRIPTION
* Unset aspect ratio of related posts to avoid large blank areas
* Add aspect ratio for stock photos
* Set giscus script data-theme tag to allow pre-load of themed giscus
* Optimize initial theme reload pass to happen before DOMContentLoaded but after giscus script is read