### PR TITLE
Color blindness support

### DIFF
--- a/_includes/a11y-menu.html
+++ b/_includes/a11y-menu.html
@@ -30,7 +30,7 @@
             class="menu-option"
             value="default"
           />
-          <span>Default</span>
+          <span>Default colors</span>
         </button>
         <button class="menu-item">
           <input

--- a/_includes/a11y-menu.html
+++ b/_includes/a11y-menu.html
@@ -21,12 +21,12 @@
         </button>
       </div>
       <hr>
-      <div id="color-blindness-filters" class="menu-container">
+      <div id="color-filters-menu" class="menu-container">
         <button class="menu-item">
           <input
             type="radio"
             id="filter-default"
-            name="color-blindness-filter"
+            name="color-filter"
             class="menu-option"
             value="default"
           />
@@ -36,7 +36,7 @@
           <input
             type="radio"
             id="filter-protanopia"
-            name="color-blindness-filter"
+            name="color-filter"
             class="menu-option"
             value="protanopia"
           />
@@ -46,7 +46,7 @@
           <input
             type="radio"
             id="filter-deuteranopia"
-            name="color-blindness-filter"
+            name="color-filter"
             class="menu-option"
             value="deuteranopia"
           />
@@ -56,7 +56,7 @@
           <input
             type="radio"
             id="filter-tritanopia"
-            name="color-blindness-filter"
+            name="color-filter"
             class="menu-option"
             value="tritanopia"
           />
@@ -66,7 +66,7 @@
           <input
             type="radio"
             id="filter-achromatopsia"
-            name="color-blindness-filter"
+            name="color-filter"
             class="menu-option"
             value="achromatopsia"
           />

--- a/_includes/a11y-menu.html
+++ b/_includes/a11y-menu.html
@@ -20,6 +20,59 @@
           <span>Large text</span>
         </button>
       </div>
+      <hr>
+      <div id="color-blindness-filters" class="menu-container">
+        <button class="menu-item">
+          <input
+            type="radio"
+            id="filter-default"
+            name="color-blindness-filter"
+            class="menu-option"
+            value="default"
+          />
+          <span>Default</span>
+        </button>
+        <button class="menu-item">
+          <input
+            type="radio"
+            id="filter-protanopia"
+            name="color-blindness-filter"
+            class="menu-option"
+            value="protanopia"
+          />
+          <span>Protanopia</span>
+        </button>
+        <button class="menu-item">
+          <input
+            type="radio"
+            id="filter-deuteranopia"
+            name="color-blindness-filter"
+            class="menu-option"
+            value="deuteranopia"
+          />
+          <span>Deuteranopia</span>
+        </button>
+        <button class="menu-item">
+          <input
+            type="radio"
+            id="filter-tritanopia"
+            name="color-blindness-filter"
+            class="menu-option"
+            value="tritanopia"
+          />
+          <span>Tritanopia</span>
+        </button>
+        <button class="menu-item">
+          <input
+            type="radio"
+            id="filter-achromatopsia"
+            name="color-blindness-filter"
+            class="menu-option"
+            value="achromatopsia"
+          />
+          <span>Achromatopsia</span>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/assets/filters/color-blindness.svg
+++ b/assets/filters/color-blindness.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Authored by https://github.com/hail2u in: https://raw.githubusercontent.com/hail2u/color-blindness-emulation/52a8e51608e87d86b3f56d3076d88b785247ca21/filters.svg under CC0 -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  version="1.1">
+  <defs>
+    <filter id="protanopia">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.567, 0.433, 0,     0, 0
+                0.558, 0.442, 0,     0, 0
+                0,     0.242, 0.758, 0, 0
+                0,     0,     0,     1, 0"/>
+    </filter>
+    <filter id="protanomaly">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.817, 0.183, 0,     0, 0
+                0.333, 0.667, 0,     0, 0
+                0,     0.125, 0.875, 0, 0
+                0,     0,     0,     1, 0"/>
+    </filter>
+    <filter id="deuteranopia">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.625, 0.375, 0,   0, 0
+                0.7,   0.3,   0,   0, 0
+                0,     0.3,   0.7, 0, 0
+                0,     0,     0,   1, 0"/>
+    </filter>
+    <filter id="deuteranomaly">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.8,   0.2,   0,     0, 0
+                0.258, 0.742, 0,     0, 0
+                0,     0.142, 0.858, 0, 0
+                0,     0,     0,     1, 0"/>
+    </filter>
+    <filter id="tritanopia">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.95, 0.05,  0,     0, 0
+                0,    0.433, 0.567, 0, 0
+                0,    0.475, 0.525, 0, 0
+                0,    0,     0,     1, 0"/>
+    </filter>
+    <filter id="tritanomaly">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.967, 0.033, 0,     0, 0
+                0,     0.733, 0.267, 0, 0
+                0,     0.183, 0.817, 0, 0
+                0,     0,     0,     1, 0"/>
+    </filter>
+    <filter id="achromatopsia">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.299, 0.587, 0.114, 0, 0
+                0.299, 0.587, 0.114, 0, 0
+                0.299, 0.587, 0.114, 0, 0
+                0,     0,     0,     1, 0"/>
+    </filter>
+    <filter id="achromatomaly">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.618, 0.320, 0.062, 0, 0
+                0.163, 0.775, 0.062, 0, 0
+                0.163, 0.320, 0.516, 0, 0
+                0,     0,     0,     1, 0"/>
+    </filter>
+  </defs>
+</svg>

--- a/assets/filters/color-blindness.svg
+++ b/assets/filters/color-blindness.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Authored by https://github.com/hail2u in: https://raw.githubusercontent.com/hail2u/color-blindness-emulation/52a8e51608e87d86b3f56d3076d88b785247ca21/filters.svg under CC0 -->
+<!-- Based on works of https://github.com/hail2u at: https://raw.githubusercontent.com/hail2u/color-blindness-emulation/52a8e51608e87d86b3f56d3076d88b785247ca21/filters.svg under CC0 -->
 <svg
   xmlns="http://www.w3.org/2000/svg"
   version="1.1">
@@ -13,15 +13,6 @@
                 0,     0.242, 0.758, 0, 0
                 0,     0,     0,     1, 0"/>
     </filter>
-    <filter id="protanomaly">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        values="0.817, 0.183, 0,     0, 0
-                0.333, 0.667, 0,     0, 0
-                0,     0.125, 0.875, 0, 0
-                0,     0,     0,     1, 0"/>
-    </filter>
     <filter id="deuteranopia">
       <feColorMatrix
         in="SourceGraphic"
@@ -30,15 +21,6 @@
                 0.7,   0.3,   0,   0, 0
                 0,     0.3,   0.7, 0, 0
                 0,     0,     0,   1, 0"/>
-    </filter>
-    <filter id="deuteranomaly">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        values="0.8,   0.2,   0,     0, 0
-                0.258, 0.742, 0,     0, 0
-                0,     0.142, 0.858, 0, 0
-                0,     0,     0,     1, 0"/>
     </filter>
     <filter id="tritanopia">
       <feColorMatrix
@@ -49,15 +31,6 @@
                 0,    0.475, 0.525, 0, 0
                 0,    0,     0,     1, 0"/>
     </filter>
-    <filter id="tritanomaly">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        values="0.967, 0.033, 0,     0, 0
-                0,     0.733, 0.267, 0, 0
-                0,     0.183, 0.817, 0, 0
-                0,     0,     0,     1, 0"/>
-    </filter>
     <filter id="achromatopsia">
       <feColorMatrix
         in="SourceGraphic"
@@ -65,15 +38,6 @@
         values="0.299, 0.587, 0.114, 0, 0
                 0.299, 0.587, 0.114, 0, 0
                 0.299, 0.587, 0.114, 0, 0
-                0,     0,     0,     1, 0"/>
-    </filter>
-    <filter id="achromatomaly">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        values="0.618, 0.320, 0.062, 0, 0
-                0.163, 0.775, 0.062, 0, 0
-                0.163, 0.320, 0.516, 0, 0
                 0,     0,     0,     1, 0"/>
     </filter>
   </defs>

--- a/assets/js/site-appearance.js
+++ b/assets/js/site-appearance.js
@@ -11,11 +11,13 @@ const giscusThemeMapping = {
   "light-contrast": "light_high_contrast",
 };
 
-const defaultChoice = "browser";
+const defaultThemeChoice = "browser";
+const defaultColorFilterChoice = "default";
 
 const themeKey = "theme";
 const contrastKey = "contrast";
 const fontSizeKey = "fontSize";
+const colorFilterKey = "colorFilter";
 
 loadAppearanceFromLocalStorage();
 
@@ -86,16 +88,21 @@ function updateLocalStorageState() {
 
   const largeFontEnabled = isLargeFontEnabled();
   localStorage.setItem(fontSizeKey, largeFontEnabled);
+
+  const colorFilter = getSelectedColorFilter();
+  localStorage.setItem(colorFilterKey, colorFilter);
 }
 
 function loadAppearanceFromLocalStorage() {
-  const themeSelection = localStorage.getItem(themeKey) || defaultChoice;
+  const themeSelection = localStorage.getItem(themeKey) || defaultThemeChoice;
   const contrastSelection = localStorage.getItem(contrastKey) === "true";
   const fontSizeSelection = localStorage.getItem(fontSizeKey) === "true";
+  const colorFilterSelection = localStorage.getItem(colorFilterKey) || defaultColorFilterChoice;
 
   setThemeChoice(themeSelection);
   setContrastChoice(contrastSelection);
   setFontSizeChoice(fontSizeSelection);
+  setColorFilterChoice(colorFilterSelection);
 
   document.documentElement.setAttribute(
     "data-theme",
@@ -103,6 +110,7 @@ function loadAppearanceFromLocalStorage() {
   );
   document.documentElement.setAttribute("data-contrast", contrastSelection);
   document.documentElement.setAttribute("data-large-font", fontSizeSelection);
+  document.documentElement.setAttribute("data-color-filter", colorFilterSelection);
 
   setThemes(themeSelection, contrastSelection);
   setDiagramsSize(fontSizeSelection);
@@ -112,12 +120,20 @@ function getSelectedTheme() {
   const selection = document.querySelector(
     '#theme-menu input[name="theme"]:checked'
   );
-  const choice = selection ? selection.value : defaultChoice;
+  const choice = selection ? selection.value : defaultThemeChoice;
   return choice;
 }
 
 function getThemeFromChoice(choice) {
   return (themeChoiceMapping[choice] || getDefaultPreference)();
+}
+
+function getSelectedColorFilter() {
+  const selection = document.querySelector(
+    '#color-filters-menu input[name="color-filter"]:checked'
+  );
+  const choice = selection ? selection.value : defaultColorFilterChoice;
+  return choice;
 }
 
 function isContrastEnabled() {
@@ -148,6 +164,13 @@ function setFontSizeChoice(choice) {
   const toggle = getFontSizeToggle();
   if (toggle) {
     toggle.value = choice;
+  }
+}
+
+function setColorFilterChoice(choice) {
+  const toggle = document.querySelector(`#color-filters-menu input[value="${choice}"]`);
+  if (toggle) {
+    toggle.checked = true;
   }
 }
 

--- a/assets/scss/_appearance.scss
+++ b/assets/scss/_appearance.scss
@@ -7,7 +7,7 @@ $contrast-slight: 125%;
 $contrast-boost: 150%;
 $contrast-border: $thin-border;
 $full-invert: invert(100%) hue-rotate(180deg);
-$color-blind-filters: "filters/color-blindness.svg";
+$color-filters: "filters/color-blindness.svg";
 
 :root {
   --content-width: 80%;
@@ -194,27 +194,27 @@ html[data-large-font="true"] {
   }
 }
 
-html[data-color-filters="protanopia"] {
+html[data-color-filter="protanopia"] {
   body {
-    filter: url($color-blind-filters + "#protanopia");
+    filter: url($color-filters + "#protanopia");
   }
 }
 
-html[data-color-filters="deuteranopia"] {
+html[data-color-filter="deuteranopia"] {
   body {
-    filter: url($color-blind-filters + "#deuteranopia");
+    filter: url($color-filters + "#deuteranopia");
   }
 }
 
-html[data-color-filters="tritanopia"] {
+html[data-color-filter="tritanopia"] {
   body {
-    filter: url($color-blind-filters + "#tritanopia");
+    filter: url($color-filters + "#tritanopia");
   }
 }
 
-html[data-color-filters="achromatopsia"] {
+html[data-color-filter="achromatopsia"] {
   body {
-    filter: url($color-blind-filters + "#achromatopsia");
+    filter: url($color-filters + "#achromatopsia");
   }
 }
 

--- a/assets/scss/_appearance.scss
+++ b/assets/scss/_appearance.scss
@@ -7,6 +7,7 @@ $contrast-slight: 125%;
 $contrast-boost: 150%;
 $contrast-border: $thin-border;
 $full-invert: invert(100%) hue-rotate(180deg);
+$color-blind-filters: "filters/color-blindness.svg";
 
 :root {
   --content-width: 80%;
@@ -190,6 +191,30 @@ html[data-large-font="true"] {
   .svg-icon {
     transform-origin: top left;
     transform: scale(1.4);
+  }
+}
+
+html[data-color-filters="protanopia"] {
+  body {
+    filter: url($color-blind-filters + "#protanopia");
+  }
+}
+
+html[data-color-filters="deuteranopia"] {
+  body {
+    filter: url($color-blind-filters + "#deuteranopia");
+  }
+}
+
+html[data-color-filters="tritanopia"] {
+  body {
+    filter: url($color-blind-filters + "#tritanopia");
+  }
+}
+
+html[data-color-filters="achromatopsia"] {
+  body {
+    filter: url($color-blind-filters + "#achromatopsia");
   }
 }
 

--- a/assets/scss/_appearance.scss
+++ b/assets/scss/_appearance.scss
@@ -32,6 +32,7 @@ $color-filters: "filters/color-blindness.svg";
   --background-color: #f8f8f8;
   --primary-box-color: #e2eaeb;
   --secondary-box-color: #e5e5e5;
+  --color-blind-scroll-hover-color: #808080;
   --default-font-size: 4.3mm;
   --desktop-font-size: 4.9mm;
 }
@@ -187,7 +188,7 @@ html[data-large-font="true"] {
     height: 1em;
     width: auto;
   }
-  
+
   .svg-icon {
     transform-origin: top left;
     transform: scale(1.4);
@@ -215,6 +216,25 @@ html[data-color-filter="tritanopia"] {
 html[data-color-filter="achromatopsia"] {
   body {
     filter: url($color-filters + "#achromatopsia");
+  }
+}
+
+:not(html[data-color-filter="default"]) {
+  /* The track (background) of the scrollbar */
+  ::-webkit-scrollbar-track {
+    background: var(--secondary-box-color); /* Color of the track */
+  }
+
+  /* The draggable thumb of the scrollbar */
+  ::-webkit-scrollbar-thumb {
+    background: var(--secondary-color); /* Color of the thumb */
+  }
+
+  /* Hover effect for the thumb */
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(
+      --color-blind-scroll-hover-color
+    ); /* Special shade for hover state */
   }
 }
 

--- a/assets/scss/_navigation.scss
+++ b/assets/scss/_navigation.scss
@@ -100,7 +100,7 @@
   border: none;
   background: none;
   border-radius: $border-radius;
-  padding: 0 $half-margin;  
+  padding: 0 $half-margin;
   margin: 0.3em 0;
   border-width: $thin-border;
   border-color: var(--background-color);
@@ -109,7 +109,9 @@
   cursor: pointer;
 }
 
-.menu-item:has(.menu-option:is(:checked, [value="true"], [data-selected="true"])) {
+.menu-item:has(
+    .menu-option:is(:checked, [value="true"], [data-selected="true"])
+  ) {
   background-color: var(--primary-color);
   border-color: var(--background-color);
   span {

--- a/assets/scss/_navigation.scss
+++ b/assets/scss/_navigation.scss
@@ -73,6 +73,13 @@
   padding: $half-margin;
   border-bottom-left-radius: $border-radius;
   border-bottom-right-radius: $border-radius;
+  hr {
+    border-top-width: $thin-border;
+    border-bottom-width: 0;
+    border-color: inherit;
+    border-style: solid;
+    margin: $half-margin;
+  }
 }
 
 .menu-toggle:checked ~ .menu-body {


### PR DESCRIPTION
- Added support for basic modes under A11y:
  - Default (no color vision impairment)
  - Protanopia
  - Deuteranopia
  - Tritanopia
  - Achromatopsia
- All modes for color vision imparment have a monochromatic scrollbar due to limitations of scrollbar pseudoelements
- Color vision impairment modes work regardless of theme and high contrast mode, however might slightly reduce contrast for dark high contrast mode due to color shifts