### PR TITLE
Adapt and simulate

### DIFF
--- a/_includes/a11y-menu.html
+++ b/_includes/a11y-menu.html
@@ -21,6 +21,17 @@
         </button>
       </div>
       <hr>
+      <div class="menu-container">
+        <button class="menu-item">
+          <input type="checkbox" id="simulate-vision-setting" class="menu-option" />
+          <span>Simulate color vision</span>
+        </button>
+        <button class="menu-item">
+          <input type="checkbox" id="adapt-vision-setting" class="menu-option" />
+          <span>Adapt to color vision</span>
+        </button>
+      </div>
+      <hr>
       <div id="color-filters-menu" class="menu-container">
         <button class="menu-item">
           <input

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,6 +12,9 @@ layout: default
 
   {% include js-required-warning.html %}
 
+  <img src="https://wallpapers.com/images/featured/rainbow-pictures-povwnf60sljd1snu.jpg"/>
+  <img src="https://www.aoa.org/AOA/Images/Patients/Eye%20Conditions/Color_Deficiency_Ishihara_Test_AdobeStock_114210620.jpg"/>
+
   {% include search-feed.html %}
 
   <p class="rss-subscribe">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,9 +12,6 @@ layout: default
 
   {% include js-required-warning.html %}
 
-  <img src="https://wallpapers.com/images/featured/rainbow-pictures-povwnf60sljd1snu.jpg"/>
-  <img src="https://www.aoa.org/AOA/Images/Patients/Eye%20Conditions/Color_Deficiency_Ishihara_Test_AdobeStock_114210620.jpg"/>
-
   {% include search-feed.html %}
 
   <p class="rss-subscribe">

--- a/assets/filters/color-filters.svg
+++ b/assets/filters/color-filters.svg
@@ -1,36 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Based on works of https://github.com/hail2u at: https://raw.githubusercontent.com/hail2u/color-blindness-emulation/52a8e51608e87d86b3f56d3076d88b785247ca21/filters.svg under CC0 -->
+<!-- 
+Based on works of :
+- https://github.com/hail2u at: https://raw.githubusercontent.com/hail2u/color-blindness-emulation/52a8e51608e87d86b3f56d3076d88b785247ca21/filters.svg under CC0 
+- https://github.com/Andrews54757 at: https://github.com/Andrews54757/SVG-Daltonizer
+-->
 <svg
   xmlns="http://www.w3.org/2000/svg"
   version="1.1">
   <defs>
-    <filter id="protanopia">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        values="0.567, 0.433, 0,     0, 0
-                0.558, 0.442, 0,     0, 0
-                0,     0.242, 0.758, 0, 0
-                0,     0,     0,     1, 0"/>
-    </filter>
-    <filter id="deuteranopia">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        values="0.625, 0.375, 0,   0, 0
-                0.7,   0.3,   0,   0, 0
-                0,     0.3,   0.7, 0, 0
-                0,     0,     0,   1, 0"/>
-    </filter>
-    <filter id="tritanopia">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        values="0.95, 0.05,  0,     0, 0
-                0,    0.433, 0.567, 0, 0
-                0,    0.475, 0.525, 0, 0
-                0,    0,     0,     1, 0"/>
-    </filter>
     <filter id="achromatopsia">
       <feColorMatrix
         in="SourceGraphic"
@@ -39,6 +16,116 @@
                 0.299, 0.587, 0.114, 0, 0
                 0.299, 0.587, 0.114, 0, 0
                 0,     0,     0,     1, 0"/>
+    </filter>
+    
+    <filter id="protanopia-adapted">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix" 
+        values="1,      0,       0,      0, 0
+                0.4789, 0.4769,  0.0442, 0, 0
+                0.5973, -0.6887, 1.0914, 0, 0
+                0,      0,       0,      1, 0"/>
+    </filter>
+    <filter id="deuteranopia-adapted">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="1,      0,       0,      0, 0
+                0.1628, 0.725,   0.1122, 0, 0
+                0.4547, -0.6454, 1.1907, 0, 0
+                0,      0,       0,      1, 0"
+      />
+    </filter>
+    <filter id="tritanopia-adapted">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="1,       0,       0,       0, 0
+                -0.1005, 1.1229,  -0.0225, 0, 0
+                -0.1836, -0.6376, 1.8212,  0, 0
+                0,       0,       0,       1, 0"/>
+    </filter>
+
+    <filter id="protanopia-simulated">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.567, 0.433, 0,     0, 0
+                0.558, 0.442, 0,     0, 0
+                0,     0.242, 0.758, 0, 0
+                0,     0,     0,     1, 0"/>
+    </filter>
+    <filter id="deuteranopia-simulated">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.625, 0.375, 0,   0, 0
+                0.7,   0.3,   0,   0, 0
+                0,     0.3,   0.7, 0, 0
+                0,     0,     0,   1, 0"/>
+    </filter>
+    <filter id="tritanopia-simulated">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="0.95, 0.05,  0,     0, 0
+                0,    0.433, 0.567, 0, 0
+                0,    0.475, 0.525, 0, 0
+                0,    0,     0,     1, 0"/>
+    </filter>
+
+    <filter id="protanopia-adapted-simulated">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix" 
+        result="Altered"
+        values="1,      0,       0,      0, 0
+                0.4789, 0.4769,  0.0442, 0, 0
+                0.5973, -0.6887, 1.0914, 0, 0
+                0,      0,       0,      1, 0"/>
+      <feColorMatrix
+        in="Altered"
+        type="matrix"
+        values="0.567, 0.433, 0,     0, 0
+                0.558, 0.442, 0,     0, 0
+                0,     0.242, 0.758, 0, 0
+                0,     0,     0,     1, 0"/>
+    </filter>
+    <filter id="deuteranopia-adapted-simulated">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        result="Altered"
+        values="1,      0,       0,      0, 0
+                0.1628, 0.725,   0.1122, 0, 0
+                0.4547, -0.6454, 1.1907, 0, 0
+                0,      0,       0,      1, 0"
+      />
+      <feColorMatrix
+        in="Altered"
+        type="matrix"
+        values="0.625, 0.375, 0,   0, 0
+                0.7,   0.3,   0,   0, 0
+                0,     0.3,   0.7, 0, 0
+                0,     0,     0,   1, 0"/>
+    </filter>
+    <filter id="tritanopia-adapted-simulated">
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        result="Altered"
+        values="1,       0,       0,       0, 0
+                -0.1005, 1.1229,  -0.0225, 0, 0
+                -0.1836, -0.6376, 1.8212,  0, 0
+                0,       0,       0,       1, 0"/>
+      <feColorMatrix
+        in="Altered"
+        type="matrix"
+        values="0.95, 0.05,  0,     0, 0
+                0,    0.433, 0.567, 0, 0
+                0,    0.475, 0.525, 0, 0
+                0,    0,     0,     1, 0"/>
     </filter>
   </defs>
 </svg>

--- a/assets/filters/color-filters.svg
+++ b/assets/filters/color-filters.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- 
 Based on works of :
-- https://github.com/hail2u at: https://raw.githubusercontent.com/hail2u/color-blindness-emulation/52a8e51608e87d86b3f56d3076d88b785247ca21/filters.svg under CC0 
+- https://github.com/hail2u at:
+https://raw.githubusercontent.com/hail2u/color-blindness-emulation/52a8e51608e87d86b3f56d3076d88b785247ca21/filters.svg
+under CC0 
 - https://github.com/Andrews54757 at: https://github.com/Andrews54757/SVG-Daltonizer
 -->
 <svg
@@ -15,13 +17,13 @@ Based on works of :
         values="0.299, 0.587, 0.114, 0, 0
                 0.299, 0.587, 0.114, 0, 0
                 0.299, 0.587, 0.114, 0, 0
-                0,     0,     0,     1, 0"/>
+                0,     0,     0,     1, 0" />
     </filter>
-    
+
     <filter id="protanopia-adapted">
       <feColorMatrix
         in="SourceGraphic"
-        type="matrix" 
+        type="matrix"
         values="1,      0,       0,      0, 0
                 0.4789, 0.4769,  0.0442, 0, 0
                 0.5973, -0.6887, 1.0914, 0, 0
@@ -54,7 +56,7 @@ Based on works of :
         values="0.567, 0.433, 0,     0, 0
                 0.558, 0.442, 0,     0, 0
                 0,     0.242, 0.758, 0, 0
-                0,     0,     0,     1, 0"/>
+                0,     0,     0,     1, 0" />
     </filter>
     <filter id="deuteranopia-simulated">
       <feColorMatrix
@@ -63,7 +65,7 @@ Based on works of :
         values="0.625, 0.375, 0,   0, 0
                 0.7,   0.3,   0,   0, 0
                 0,     0.3,   0.7, 0, 0
-                0,     0,     0,   1, 0"/>
+                0,     0,     0,   1, 0" />
     </filter>
     <filter id="tritanopia-simulated">
       <feColorMatrix
@@ -72,60 +74,7 @@ Based on works of :
         values="0.95, 0.05,  0,     0, 0
                 0,    0.433, 0.567, 0, 0
                 0,    0.475, 0.525, 0, 0
-                0,    0,     0,     1, 0"/>
-    </filter>
-
-    <filter id="protanopia-adapted-simulated">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix" 
-        result="Altered"
-        values="1,      0,       0,      0, 0
-                0.4789, 0.4769,  0.0442, 0, 0
-                0.5973, -0.6887, 1.0914, 0, 0
-                0,      0,       0,      1, 0"/>
-      <feColorMatrix
-        in="Altered"
-        type="matrix"
-        values="0.567, 0.433, 0,     0, 0
-                0.558, 0.442, 0,     0, 0
-                0,     0.242, 0.758, 0, 0
-                0,     0,     0,     1, 0"/>
-    </filter>
-    <filter id="deuteranopia-adapted-simulated">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        result="Altered"
-        values="1,      0,       0,      0, 0
-                0.1628, 0.725,   0.1122, 0, 0
-                0.4547, -0.6454, 1.1907, 0, 0
-                0,      0,       0,      1, 0"
-      />
-      <feColorMatrix
-        in="Altered"
-        type="matrix"
-        values="0.625, 0.375, 0,   0, 0
-                0.7,   0.3,   0,   0, 0
-                0,     0.3,   0.7, 0, 0
-                0,     0,     0,   1, 0"/>
-    </filter>
-    <filter id="tritanopia-adapted-simulated">
-      <feColorMatrix
-        in="SourceGraphic"
-        type="matrix"
-        result="Altered"
-        values="1,       0,       0,       0, 0
-                -0.1005, 1.1229,  -0.0225, 0, 0
-                -0.1836, -0.6376, 1.8212,  0, 0
-                0,       0,       0,       1, 0"/>
-      <feColorMatrix
-        in="Altered"
-        type="matrix"
-        values="0.95, 0.05,  0,     0, 0
-                0,    0.433, 0.567, 0, 0
-                0,    0.475, 0.525, 0, 0
-                0,    0,     0,     1, 0"/>
+                0,    0,     0,     1, 0" />
     </filter>
   </defs>
 </svg>

--- a/assets/filters/color-filters.svg
+++ b/assets/filters/color-filters.svg
@@ -8,19 +8,20 @@ under CC0
 -->
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  version="1.1">
+  version="1.1" 
+  style="position: fixed; height: 0px;">
   <defs>
-    <filter id="achromatopsia">
+    <filter id="achromatopsia" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%">
       <feColorMatrix
         in="SourceGraphic"
         type="matrix"
         values="0.299, 0.587, 0.114, 0, 0
                 0.299, 0.587, 0.114, 0, 0
                 0.299, 0.587, 0.114, 0, 0
-                0,     0,     0,     1, 0" />
+                0,     0,     0,     1, 0"/>
     </filter>
 
-    <filter id="protanopia-adapted">
+    <filter id="protanopia-adapted" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%">
       <feColorMatrix
         in="SourceGraphic"
         type="matrix"
@@ -29,7 +30,7 @@ under CC0
                 0.5973, -0.6887, 1.0914, 0, 0
                 0,      0,       0,      1, 0"/>
     </filter>
-    <filter id="deuteranopia-adapted">
+    <filter id="deuteranopia-adapted" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%">
       <feColorMatrix
         in="SourceGraphic"
         type="matrix"
@@ -39,7 +40,7 @@ under CC0
                 0,      0,       0,      1, 0"
       />
     </filter>
-    <filter id="tritanopia-adapted">
+    <filter id="tritanopia-adapted" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%">
       <feColorMatrix
         in="SourceGraphic"
         type="matrix"
@@ -49,7 +50,7 @@ under CC0
                 0,       0,       0,       1, 0"/>
     </filter>
 
-    <filter id="protanopia-simulated">
+    <filter id="protanopia-simulated" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%">
       <feColorMatrix
         in="SourceGraphic"
         type="matrix"
@@ -58,7 +59,7 @@ under CC0
                 0,     0.242, 0.758, 0, 0
                 0,     0,     0,     1, 0" />
     </filter>
-    <filter id="deuteranopia-simulated">
+    <filter id="deuteranopia-simulated" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%">
       <feColorMatrix
         in="SourceGraphic"
         type="matrix"
@@ -67,7 +68,7 @@ under CC0
                 0,     0.3,   0.7, 0, 0
                 0,     0,     0,   1, 0" />
     </filter>
-    <filter id="tritanopia-simulated">
+    <filter id="tritanopia-simulated" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%">
       <feColorMatrix
         in="SourceGraphic"
         type="matrix"

--- a/assets/js/site-appearance.js
+++ b/assets/js/site-appearance.js
@@ -18,6 +18,8 @@ const themeKey = "theme";
 const contrastKey = "contrast";
 const fontSizeKey = "fontSize";
 const colorFilterKey = "colorFilter";
+const colorAdaptKey = "colorAdapt";
+const colorSimulateKey = "colorSimulate";
 
 loadAppearanceFromLocalStorage();
 
@@ -89,6 +91,12 @@ function updateLocalStorageState() {
   const largeFontEnabled = isLargeFontEnabled();
   localStorage.setItem(fontSizeKey, largeFontEnabled);
 
+  const colorAdaptEnabled = isColorAdaptEnabled();
+  localStorage.setItem(colorAdaptKey, colorAdaptEnabled);
+
+  const colorSimulateEnabled = isColorSimulateEnabled();
+  localStorage.setItem(colorSimulateKey, colorSimulateEnabled);
+
   const colorFilter = getSelectedColorFilter();
   localStorage.setItem(colorFilterKey, colorFilter);
 }
@@ -97,12 +105,18 @@ function loadAppearanceFromLocalStorage() {
   const themeSelection = localStorage.getItem(themeKey) || defaultThemeChoice;
   const contrastSelection = localStorage.getItem(contrastKey) === "true";
   const fontSizeSelection = localStorage.getItem(fontSizeKey) === "true";
-  const colorFilterSelection = localStorage.getItem(colorFilterKey) || defaultColorFilterChoice;
+  const colorAdaptSelection = localStorage.getItem(colorAdaptKey) === "true";
+  const colorSimulateSelection =
+    localStorage.getItem(colorSimulateKey) === "true";
+  const colorFilterSelection =
+    localStorage.getItem(colorFilterKey) || defaultColorFilterChoice;
 
   setThemeChoice(themeSelection);
   setContrastChoice(contrastSelection);
   setFontSizeChoice(fontSizeSelection);
   setColorFilterChoice(colorFilterSelection);
+  setColorAdaptChoice(colorAdaptSelection);
+  setColorSimulateChoice(colorSimulateSelection);
 
   document.documentElement.setAttribute(
     "data-theme",
@@ -110,7 +124,18 @@ function loadAppearanceFromLocalStorage() {
   );
   document.documentElement.setAttribute("data-contrast", contrastSelection);
   document.documentElement.setAttribute("data-large-font", fontSizeSelection);
-  document.documentElement.setAttribute("data-color-filter", colorFilterSelection);
+  document.documentElement.setAttribute(
+    "data-color-filter",
+    colorFilterSelection
+  );
+  document.documentElement.setAttribute(
+    "data-adapt-vision-impairment",
+    colorAdaptSelection
+  );
+  document.documentElement.setAttribute(
+    "data-simulate-vision-impairment",
+    colorSimulateSelection
+  );
 
   setThemes(themeSelection, contrastSelection);
   setDiagramsSize(fontSizeSelection);
@@ -146,6 +171,16 @@ function isLargeFontEnabled() {
   return toggle ? toggle.value : false;
 }
 
+function isColorAdaptEnabled() {
+  const toggle = getColorAdaptToggle();
+  return toggle ? toggle.value : false;
+}
+
+function isColorSimulateEnabled() {
+  const toggle = getColorSimulateToggle();
+  return toggle ? toggle.value : false;
+}
+
 function setThemeChoice(choice) {
   const toggle = document.querySelector(`#theme-menu input[value="${choice}"]`);
   if (toggle) {
@@ -167,8 +202,24 @@ function setFontSizeChoice(choice) {
   }
 }
 
+function setColorAdaptChoice(choice) {
+  const toggle = getColorAdaptToggle();
+  if (toggle) {
+    toggle.value = choice;
+  }
+}
+
+function setColorSimulateChoice(choice) {
+  const toggle = getColorSimulateToggle();
+  if (toggle) {
+    toggle.value = choice;
+  }
+}
+
 function setColorFilterChoice(choice) {
-  const toggle = document.querySelector(`#color-filters-menu input[value="${choice}"]`);
+  const toggle = document.querySelector(
+    `#color-filters-menu input[value="${choice}"]`
+  );
   if (toggle) {
     toggle.checked = true;
   }
@@ -180,6 +231,14 @@ function getContrastToggle() {
 
 function getFontSizeToggle() {
   return document.getElementById("font-size-setting");
+}
+
+function getColorAdaptToggle() {
+  return document.getElementById("adapt-vision-setting");
+}
+
+function getColorSimulateToggle() {
+  return document.getElementById("simulate-vision-setting");
 }
 
 function setThemes(themeSelection, contrastEnabled) {

--- a/assets/scss/_appearance.scss
+++ b/assets/scss/_appearance.scss
@@ -252,19 +252,19 @@ html[data-simulate-vision-impairment="true"] {
 html[data-adapt-vision-impairment="true"][data-simulate-vision-impairment="true"] {
   &[data-color-filter="protanopia"] {
     body {
-      filter: url($color-filters + "#protanopia-adapted-simulated");
+      filter: url($color-filters + "#protanopia-adapted") url($color-filters + "#protanopia-simulated");
     }
   }
 
   &[data-color-filter="deuteranopia"] {
     body {
-      filter: url($color-filters + "#deuteranopia-adapted-simulated");
+      filter: url($color-filters + "#deuteranopia-adapted") url($color-filters + "#deuteranopia-simulated");
     }
   }
 
   &[data-color-filter="tritanopia"] {
     body {
-      filter: url($color-filters + "#tritanopia-adapted-simulated");
+      filter: url($color-filters + "#tritanopia-adapted") url($color-filters + "#tritanopia-simulated");
     }
   }
 }

--- a/assets/scss/_appearance.scss
+++ b/assets/scss/_appearance.scss
@@ -33,6 +33,8 @@ $color-filters: "filters/color-filters.svg";
   --primary-box-color: #e2eaeb;
   --secondary-box-color: #e5e5e5;
   --color-blind-scroll-hover-color: #808080;
+  --adapt-vision-impairment-suffix: "";
+  --simulate-vision-impairment-suffix: "";
   --default-font-size: 4.3mm;
   --desktop-font-size: 4.9mm;
 }
@@ -195,27 +197,75 @@ html[data-large-font="true"] {
   }
 }
 
-html[data-color-filter="protanopia"] {
-  body {
-    filter: url($color-filters + "#protanopia");
+html[data-adapt-vision-impairment="true"] {
+  &[data-color-filter="protanopia"] {
+    body {
+      filter: url($color-filters + "#protanopia-adapted");
+    }
+  }
+
+  &[data-color-filter="deuteranopia"] {
+    body {
+      filter: url($color-filters + "#deuteranopia-adapted");
+    }
+  }
+
+  &[data-color-filter="tritanopia"] {
+    body {
+      filter: url($color-filters + "#tritanopia-adapted");
+    }
+  }
+
+  &[data-color-filter="achromatopsia"] {
+    body {
+      filter: url($color-filters + "#achromatopsia");
+    }
   }
 }
 
-html[data-color-filter="deuteranopia"] {
-  body {
-    filter: url($color-filters + "#deuteranopia");
+html[data-simulate-vision-impairment="true"] {
+  &[data-color-filter="protanopia"] {
+    body {
+      filter: url($color-filters + "#protanopia-simulated");
+    }
+  }
+
+  &[data-color-filter="deuteranopia"] {
+    body {
+      filter: url($color-filters + "#deuteranopia-simulated");
+    }
+  }
+
+  &[data-color-filter="tritanopia"] {
+    body {
+      filter: url($color-filters + "#tritanopia-simulated");
+    }
+  }
+
+  &[data-color-filter="achromatopsia"] {
+    body {
+      filter: url($color-filters + "#achromatopsia");
+    }
   }
 }
 
-html[data-color-filter="tritanopia"] {
-  body {
-    filter: url($color-filters + "#tritanopia");
+html[data-adapt-vision-impairment="true"][data-simulate-vision-impairment="true"] {
+  &[data-color-filter="protanopia"] {
+    body {
+      filter: url($color-filters + "#protanopia-adapted-simulated");
+    }
   }
-}
 
-html[data-color-filter="achromatopsia"] {
-  body {
-    filter: url($color-filters + "#achromatopsia");
+  &[data-color-filter="deuteranopia"] {
+    body {
+      filter: url($color-filters + "#deuteranopia-adapted-simulated");
+    }
+  }
+
+  &[data-color-filter="tritanopia"] {
+    body {
+      filter: url($color-filters + "#tritanopia-adapted-simulated");
+    }
   }
 }
 


### PR DESCRIPTION
- Introduce adaptation, based on 3rd party "daltonize" SVG filters, levergaing "Machado" filters
- Separate "adapt" and "simulate" toggles
- Simulate toggle enables website mode that should resemble color vision impairment
- Adapt toggle should adapt site colors to make them more distinguishable with color vision impairment